### PR TITLE
Correspond to Swift 4

### DIFF
--- a/FormSheetTextView.podspec
+++ b/FormSheetTextView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FormSheetTextView'
-  s.version = '1.0.3'
+  s.version = '1.1.0'
   s.license = 'MIT'
   s.summary = 'FormSheetTextView is a FormSheet style UITextView.'
   s.homepage = 'https://github.com/tichise/FormSheetTextView'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/*.swift'
   s.requires_arc = true
-  
+
   s.resource_bundles = {
     'Storyboards' => [
         'Storyboards/*.storyboard'

--- a/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Sample/Sample.xcodeproj/project.pbxproj
@@ -220,13 +220,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = ichise;
 				TargetAttributes = {
 					798268F91F1F269B0090613B = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = T33NHY384Q;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
 					7982690D1F1F269B0090613B = {
@@ -461,7 +461,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -469,7 +471,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -498,6 +504,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 			};
 			name = Debug;
 		};
@@ -510,7 +517,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -518,7 +527,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -539,6 +552,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -553,7 +567,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = test.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -568,7 +583,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = test.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -584,7 +600,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.co.paperboy.SampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/Sample";
 			};
 			name = Debug;
@@ -600,7 +616,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.co.paperboy.SampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/Sample";
 			};
 			name = Release;
@@ -615,7 +631,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.co.paperboy.SampleUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = Sample;
 			};
 			name = Debug;
@@ -630,7 +646,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jp.co.paperboy.SampleUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = Sample;
 			};
 			name = Release;

--- a/SampleObjectiveC/SampleObjectiveC.xcodeproj/project.pbxproj
+++ b/SampleObjectiveC/SampleObjectiveC.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = test.SampleObjectiveC;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -371,7 +371,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = test.SampleObjectiveC;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Sources/FormSheetTextViewController.swift
+++ b/Sources/FormSheetTextViewController.swift
@@ -26,10 +26,10 @@ open class FormSheetTextViewController: UIViewController {
     
     @IBOutlet weak var bottomConstraint: NSLayoutConstraint!
     
-    open var completionHandler: ((_ sendText: String) -> Void)?
+    @objc open var completionHandler: ((_ sendText: String) -> Void)?
     
     
-    open static func instantiate() -> FormSheetTextViewController {
+    @objc open static func instantiate() -> FormSheetTextViewController {
         let storyboardsBundle = getStoryboardsBundle()
         let formSheetTextViewController = UIStoryboard(name: "FormSheet", bundle: storyboardsBundle).instantiateInitialViewController() as! FormSheetTextViewController
 
@@ -70,31 +70,31 @@ open class FormSheetTextViewController: UIViewController {
         composeTextView?.becomeFirstResponder()
     }
     
-    public func setInitialText(_ text:String) {
+    @objc public func setInitialText(_ text:String) {
         self.initialText = text
     }
     
-    public func setTitleText(_ text:String) {
+    @objc public func setTitleText(_ text:String) {
         self.titleText = text
     }
     
-    public func setPreviewPageTitle(_ text:String) {
+    @objc public func setPreviewPageTitle(_ text:String) {
         self.previewPageTitle = text
     }
     
-    public func setCancelButtonText(_ text:String) {
+    @objc public func setCancelButtonText(_ text:String) {
         self.cancelButonText = text
     }
     
-    public func setSendButtonText(_ text:String) {
+    @objc public func setSendButtonText(_ text:String) {
         self.sendButtonText = text
     }
     
-    public func setTitleSize(_ size:CGFloat) {
+    @objc public func setTitleSize(_ size:CGFloat) {
         self.titleSize = size
     }
     
-    public func setButtonSize(_ size:CGFloat) {
+    @objc public func setButtonSize(_ size:CGFloat) {
         self.buttonSize = size
     }
     
@@ -223,11 +223,11 @@ open class FormSheetTextViewController: UIViewController {
         composeTextView?.inputAccessoryView = toolbar
     }
     
-    public func setIsPreview (_ isPreview:Bool) {
+    @objc public func setIsPreview (_ isPreview:Bool) {
         self.isPreview = isPreview
     }
     
-    public func setIsInitialPositionHead(_ isInitialPositionHead:Bool) {
+    @objc public func setIsInitialPositionHead(_ isInitialPositionHead:Bool) {
         self.isInitialPositionHead = isInitialPositionHead
     }
 }

--- a/Sources/FormSheetTextViewController.swift
+++ b/Sources/FormSheetTextViewController.swift
@@ -47,7 +47,7 @@ open class FormSheetTextViewController: UIViewController {
         
         if (titleSize != nil) {
             self.navigationController?.navigationBar.titleTextAttributes
-                = [NSFontAttributeName: UIFont.systemFont(ofSize: titleSize!)]
+                = [NSAttributedStringKey.font: UIFont.systemFont(ofSize: titleSize!)]
         }
     
         
@@ -120,11 +120,11 @@ open class FormSheetTextViewController: UIViewController {
         return bundle
     }
     
-    func UIKeyboardWillShow(notification: NSNotification) {
+    @objc func UIKeyboardWillShow(notification: NSNotification) {
         keyboardWillChangeFrame(notification: notification)
     }
     
-    func keyboardWillChangeFrame(notification: NSNotification) {
+    @objc func keyboardWillChangeFrame(notification: NSNotification) {
         let info: [AnyHashable: Any]? = notification.userInfo
         
         let windowHeight = UIScreen.main.bounds.size.height
@@ -157,7 +157,7 @@ open class FormSheetTextViewController: UIViewController {
         })
     }
     
-    func keyboardWillHide(_ notification: Notification) {
+    @objc func keyboardWillHide(_ notification: Notification) {
         let info: [AnyHashable: Any]? = notification.userInfo
         bottomConstraint.constant = 10
         
@@ -171,7 +171,7 @@ open class FormSheetTextViewController: UIViewController {
         let leftButton = UIBarButtonItem(title: cancelButonText, style: UIBarButtonItemStyle.plain, target: self, action:#selector(FormSheetTextViewController.cancel(sender:)))
         
         if (buttonSize != nil) {
-            leftButton.setTitleTextAttributes([NSFontAttributeName: UIFont.systemFont(ofSize: buttonSize!)], for: UIControlState.normal)
+            leftButton.setTitleTextAttributes([NSAttributedStringKey.font: UIFont.systemFont(ofSize: buttonSize!)], for: UIControlState.normal)
         }
         
         self.navigationItem.leftBarButtonItem = leftButton
@@ -182,13 +182,13 @@ open class FormSheetTextViewController: UIViewController {
         let rightButton = UIBarButtonItem(title: sendButtonText, style: UIBarButtonItemStyle.plain, target: self, action: #selector(FormSheetTextViewController.send(sender:)))
         
         if (buttonSize != nil) {
-            rightButton.setTitleTextAttributes([NSFontAttributeName: UIFont.systemFont(ofSize: buttonSize!)], for: UIControlState.normal)
+            rightButton.setTitleTextAttributes([NSAttributedStringKey.font: UIFont.systemFont(ofSize: buttonSize!)], for: UIControlState.normal)
         }
         
         self.navigationItem.rightBarButtonItem = rightButton
     }
     
-    func preview() {
+    @objc func preview() {
         performSegue(withIdentifier: seguePushPreview, sender: nil)
     }
     
@@ -208,8 +208,8 @@ open class FormSheetTextViewController: UIViewController {
         let paragrahStyle = NSMutableParagraphStyle()
         paragrahStyle.lineSpacing = 10.0
         let attributedText = NSMutableAttributedString(string: defaultString)
-        attributedText.addAttribute(NSParagraphStyleAttributeName, value: paragrahStyle, range: NSRange(location: 0, length: attributedText.length))
-        attributedText.addAttribute(NSFontAttributeName, value: bodyFont, range: NSRange(location: 0, length: attributedText.length))
+        attributedText.addAttribute(NSAttributedStringKey.paragraphStyle, value: paragrahStyle, range: NSRange(location: 0, length: attributedText.length))
+        attributedText.addAttribute(NSAttributedStringKey.font, value: bodyFont, range: NSRange(location: 0, length: attributedText.length))
         composeTextView?.attributedText = attributedText
         
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: 45))


### PR DESCRIPTION
#### things to do
- I will correspond to Swift 4.

### What did 
 - I will change SWIFT_SWIFT3_OBJC_INFERENCE for all targs off.
 - I add @objc to the method called from ObjectiveC.
 - I will rewrite the method which changed writing style with Swift 4 notation.
